### PR TITLE
fix: ensure that points array is cleaned up in routing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -57,27 +57,6 @@
                 "node": ">=6.0.0"
             }
         },
-        "node_modules/@asamuzakjp/css-color": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.1.1.tgz",
-            "integrity": "sha512-hpRD68SV2OMcZCsrbdkccTw5FXjNDLo5OuqSHyHZfwweGsDWZwDJ2+gONyNAbazZclobMirACLw0lk8WVxIqxA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@csstools/css-calc": "^2.1.2",
-                "@csstools/css-color-parser": "^3.0.8",
-                "@csstools/css-parser-algorithms": "^3.0.4",
-                "@csstools/css-tokenizer": "^3.0.3",
-                "lru-cache": "^10.4.3"
-            }
-        },
-        "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
-            "version": "10.4.3",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-            "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-            "dev": true,
-            "license": "ISC"
-        },
         "node_modules/@babel/code-frame": {
             "version": "7.26.2",
             "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.26.2.tgz",
@@ -2365,123 +2344,6 @@
                 "@jridgewell/sourcemap-codec": "^1.4.10"
             }
         },
-        "node_modules/@csstools/color-helpers": {
-            "version": "5.0.2",
-            "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.0.2.tgz",
-            "integrity": "sha512-JqWH1vsgdGcw2RR6VliXXdA0/59LttzlU8UlRT/iUUsEeWfYq8I+K0yhihEUTTHLRm1EXvpsCx3083EU15ecsA==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/csstools"
-                },
-                {
-                    "type": "opencollective",
-                    "url": "https://opencollective.com/csstools"
-                }
-            ],
-            "license": "MIT-0",
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@csstools/css-calc": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.2.tgz",
-            "integrity": "sha512-TklMyb3uBB28b5uQdxjReG4L80NxAqgrECqLZFQbyLekwwlcDDS8r3f07DKqeo8C4926Br0gf/ZDe17Zv4wIuw==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/csstools"
-                },
-                {
-                    "type": "opencollective",
-                    "url": "https://opencollective.com/csstools"
-                }
-            ],
-            "license": "MIT",
-            "engines": {
-                "node": ">=18"
-            },
-            "peerDependencies": {
-                "@csstools/css-parser-algorithms": "^3.0.4",
-                "@csstools/css-tokenizer": "^3.0.3"
-            }
-        },
-        "node_modules/@csstools/css-color-parser": {
-            "version": "3.0.8",
-            "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.0.8.tgz",
-            "integrity": "sha512-pdwotQjCCnRPuNi06jFuP68cykU1f3ZWExLe/8MQ1LOs8Xq+fTkYgd+2V8mWUWMrOn9iS2HftPVaMZDaXzGbhQ==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/csstools"
-                },
-                {
-                    "type": "opencollective",
-                    "url": "https://opencollective.com/csstools"
-                }
-            ],
-            "license": "MIT",
-            "dependencies": {
-                "@csstools/color-helpers": "^5.0.2",
-                "@csstools/css-calc": "^2.1.2"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "peerDependencies": {
-                "@csstools/css-parser-algorithms": "^3.0.4",
-                "@csstools/css-tokenizer": "^3.0.3"
-            }
-        },
-        "node_modules/@csstools/css-parser-algorithms": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.4.tgz",
-            "integrity": "sha512-Up7rBoV77rv29d3uKHUIVubz1BTcgyUK72IvCQAbfbMv584xHcGKCKbWh7i8hPrRJ7qU4Y8IO3IY9m+iTB7P3A==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/csstools"
-                },
-                {
-                    "type": "opencollective",
-                    "url": "https://opencollective.com/csstools"
-                }
-            ],
-            "license": "MIT",
-            "peer": true,
-            "engines": {
-                "node": ">=18"
-            },
-            "peerDependencies": {
-                "@csstools/css-tokenizer": "^3.0.3"
-            }
-        },
-        "node_modules/@csstools/css-tokenizer": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.3.tgz",
-            "integrity": "sha512-UJnjoFsmxfKUdNYdWgOB0mWUypuLvAfQPH1+pyvRJs6euowbFkFC6P13w1l8mJyi3vxYMxc9kld5jZEGRQs6bw==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/csstools"
-                },
-                {
-                    "type": "opencollective",
-                    "url": "https://opencollective.com/csstools"
-                }
-            ],
-            "license": "MIT",
-            "peer": true,
-            "engines": {
-                "node": ">=18"
-            }
-        },
         "node_modules/@esbuild/aix-ppc64": {
             "version": "0.25.2",
             "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.2.tgz",
@@ -2883,9 +2745,9 @@
             }
         },
         "node_modules/@eslint-community/eslint-utils": {
-            "version": "4.5.1",
-            "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.5.1.tgz",
-            "integrity": "sha512-soEIOALTfTK6EjmKMMoLugwaP0rzkad90iIWd1hMO9ARkSAyjfMfkRRhLvD5qH7vvM0Cg72pieUfR6yh6XxC4w==",
+            "version": "4.9.1",
+            "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+            "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2940,9 +2802,9 @@
             }
         },
         "node_modules/@eslint/eslintrc": {
-            "version": "3.3.1",
-            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.1.tgz",
-            "integrity": "sha512-gtF186CXhIl1p4pJNGZw8Yc6RlshoePRvE0X91oPGb3vZ8pM3qOS9W9NGPat9LziaBV7XrJWGylNQXkGcnM3IQ==",
+            "version": "3.3.3",
+            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.3.tgz",
+            "integrity": "sha512-Kr+LPIUVKz2qkx1HAMH8q1q6azbqBAsXJUxBl/ODDuVPX45Z9DfwB8tPjTi6nNZ8BuM3nbJxC5zCAg5elnBUTQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2952,7 +2814,7 @@
                 "globals": "^14.0.0",
                 "ignore": "^5.2.0",
                 "import-fresh": "^3.2.1",
-                "js-yaml": "^4.1.0",
+                "js-yaml": "^4.1.1",
                 "minimatch": "^3.1.2",
                 "strip-json-comments": "^3.1.1"
             },
@@ -4224,9 +4086,9 @@
             }
         },
         "node_modules/@types/estree": {
-            "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.7.tgz",
-            "integrity": "sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==",
+            "version": "1.0.8",
+            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+            "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
             "dev": true,
             "license": "MIT"
         },
@@ -4879,9 +4741,9 @@
             "license": "BSD-3-Clause"
         },
         "node_modules/acorn": {
-            "version": "8.14.1",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz",
-            "integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
+            "version": "8.16.0",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+            "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
             "dev": true,
             "license": "MIT",
             "peer": true,
@@ -4901,6 +4763,19 @@
             "dependencies": {
                 "acorn": "^8.1.0",
                 "acorn-walk": "^8.0.2"
+            }
+        },
+        "node_modules/acorn-import-phases": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/acorn-import-phases/-/acorn-import-phases-1.0.4.tgz",
+            "integrity": "sha512-wKmbr/DDiIXzEOiWrTTUcDm24kQ2vGfZQvM2fwg2vXqR5uW6aapr7ObPtj1th32b9u90/Pf4AItvdTh42fBmVQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10.13.0"
+            },
+            "peerDependencies": {
+                "acorn": "^8.14.0"
             }
         },
         "node_modules/acorn-jsx": {
@@ -4933,16 +4808,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/agent-base": {
-            "version": "7.1.3",
-            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
-            "integrity": "sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 14"
-            }
-        },
         "node_modules/aggregate-error": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
@@ -4958,9 +4823,9 @@
             }
         },
         "node_modules/ajv": {
-            "version": "8.17.1",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-            "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+            "version": "8.18.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+            "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
             "dev": true,
             "license": "MIT",
             "peer": true,
@@ -5466,6 +5331,19 @@
             "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
             "dev": true
         },
+        "node_modules/baseline-browser-mapping": {
+            "version": "2.10.0",
+            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.0.tgz",
+            "integrity": "sha512-lIyg0szRfYbiy67j9KN8IyeD7q7hcmqnJ1ddWmNt19ItGpNN64mnllmxUNFIOdOm6by97jlL6wfpTTJrmnjWAA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "bin": {
+                "baseline-browser-mapping": "dist/cli.cjs"
+            },
+            "engines": {
+                "node": ">=6.0.0"
+            }
+        },
         "node_modules/boolbase": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
@@ -5657,9 +5535,9 @@
             }
         },
         "node_modules/browserslist": {
-            "version": "4.24.4",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.4.tgz",
-            "integrity": "sha512-KDi1Ny1gSePi1vm0q4oxSF8b4DR44GF4BbmS2YdhPLOEqd8pDviZOGH/GsmRwoWJ2+5Lr085X7naowMwKHDG1A==",
+            "version": "4.28.1",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
+            "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
             "dev": true,
             "funding": [
                 {
@@ -5675,12 +5553,14 @@
                     "url": "https://github.com/sponsors/ai"
                 }
             ],
+            "license": "MIT",
             "peer": true,
             "dependencies": {
-                "caniuse-lite": "^1.0.30001688",
-                "electron-to-chromium": "^1.5.73",
-                "node-releases": "^2.0.19",
-                "update-browserslist-db": "^1.1.1"
+                "baseline-browser-mapping": "^2.9.0",
+                "caniuse-lite": "^1.0.30001759",
+                "electron-to-chromium": "^1.5.263",
+                "node-releases": "^2.0.27",
+                "update-browserslist-db": "^1.2.0"
             },
             "bin": {
                 "browserslist": "cli.js"
@@ -6117,9 +5997,9 @@
             }
         },
         "node_modules/commit-and-tag-version": {
-            "version": "12.5.0",
-            "resolved": "https://registry.npmjs.org/commit-and-tag-version/-/commit-and-tag-version-12.5.0.tgz",
-            "integrity": "sha512-Ll7rkKntH20iEFOPUT4e503Jf3J0J8jSN+aSeHuvNdtv4xmv9kSLSBg2CWsMVihwF3J2WvMHBEUSCKuDNesiTA==",
+            "version": "12.6.1",
+            "resolved": "https://registry.npmjs.org/commit-and-tag-version/-/commit-and-tag-version-12.6.1.tgz",
+            "integrity": "sha512-QNwgDDrg44oFAiLwXChOGabeGlkuaEvD7lUbLYleWLmOVYqFidek0G6xUE1NbRtitkOrDx8fuFh8w17+nUCOYg==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -6128,16 +6008,15 @@
                 "conventional-changelog-config-spec": "2.1.0",
                 "conventional-changelog-conventionalcommits": "6.1.0",
                 "conventional-recommended-bump": "7.0.1",
-                "detect-indent": "^6.0.0",
+                "detect-indent": "^6.1.0",
                 "detect-newline": "^3.1.0",
                 "dotgitignore": "^2.1.0",
-                "figures": "^3.1.0",
+                "fast-xml-parser": "^5.2.5",
+                "figures": "^3.2.0",
                 "find-up": "^5.0.0",
-                "git-semver-tags": "^5.0.0",
-                "jsdom": "^25.0.0",
-                "semver": "^7.6.3",
-                "w3c-xmlserializer": "^5.0.0",
-                "yaml": "^2.4.1",
+                "git-semver-tags": "^5.0.1",
+                "semver": "^7.7.2",
+                "yaml": "^2.6.0",
                 "yargs": "^17.7.2"
             },
             "bin": {
@@ -6347,9 +6226,9 @@
             }
         },
         "node_modules/commit-and-tag-version/node_modules/semver": {
-            "version": "7.7.1",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
-            "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+            "version": "7.7.4",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+            "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
             "dev": true,
             "license": "ISC",
             "bin": {
@@ -7147,27 +7026,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/cssstyle": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.3.0.tgz",
-            "integrity": "sha512-6r0NiY0xizYqfBvWp1G7WXJ06/bZyrk7Dc6PHql82C/pKGUTKu4yAX4Y8JPamb1ob9nBKuxWzCGTRuGwU3yxJQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@asamuzakjp/css-color": "^3.1.1",
-                "rrweb-cssom": "^0.8.0"
-            },
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/cssstyle/node_modules/rrweb-cssom": {
-            "version": "0.8.0",
-            "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
-            "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/dargs": {
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/dargs/-/dargs-7.0.0.tgz",
@@ -7176,20 +7034,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/data-urls": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
-            "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "whatwg-mimetype": "^4.0.0",
-                "whatwg-url": "^14.0.0"
-            },
-            "engines": {
-                "node": ">=18"
             }
         },
         "node_modules/data-view-buffer": {
@@ -7485,9 +7329,9 @@
             }
         },
         "node_modules/diff": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-            "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
+            "integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
             "dev": true,
             "license": "BSD-3-Clause",
             "engines": {
@@ -7736,10 +7580,11 @@
             }
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.5.129",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.129.tgz",
-            "integrity": "sha512-JlXUemX4s0+9f8mLqib/bHH8gOHf5elKS6KeWG3sk3xozb/JTq/RLXIv8OKUWiK4Ah00Wm88EFj5PYkFr4RUPA==",
-            "dev": true
+            "version": "1.5.286",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.286.tgz",
+            "integrity": "sha512-9tfDXhJ4RKFNerfjdCcZfufu49vg620741MNs26a9+bhLThdB+plgMeou98CAaHu/WATj2iHOOHTp1hWtABj2A==",
+            "dev": true,
+            "license": "ISC"
         },
         "node_modules/emittery": {
             "version": "0.13.1",
@@ -7767,14 +7612,14 @@
             "license": "MIT"
         },
         "node_modules/enhanced-resolve": {
-            "version": "5.18.1",
-            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.18.1.tgz",
-            "integrity": "sha512-ZSW3ma5GkcQBIpwZTSRAI8N71Uuwgs93IezB7mf7R60tC8ZbJideoDNKjHn2O9KIlx6rkGTTEk1xUCK2E1Y2Yg==",
+            "version": "5.19.0",
+            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.19.0.tgz",
+            "integrity": "sha512-phv3E1Xl4tQOShqSte26C7Fl84EwUdZsyOuSSk9qtAGyyQs2s3jJzComh+Abf4g187lUUAvH+H26omrqia2aGg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "graceful-fs": "^4.2.4",
-                "tapable": "^2.2.0"
+                "tapable": "^2.3.0"
             },
             "engines": {
                 "node": ">=10.13.0"
@@ -7889,9 +7734,9 @@
             }
         },
         "node_modules/es-module-lexer": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.6.0.tgz",
-            "integrity": "sha512-qqnD1yMU6tk/jnaMosogGySTZP8YtUgAffA9nMN+E/rjxcfRQ6IEk7IiozUjgxKoFHBGjTLnrHB/YC45r/59EQ==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
+            "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
             "dev": true,
             "license": "MIT"
         },
@@ -8505,6 +8350,25 @@
                 }
             ],
             "license": "BSD-3-Clause"
+        },
+        "node_modules/fast-xml-parser": {
+            "version": "5.3.6",
+            "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.3.6.tgz",
+            "integrity": "sha512-QNI3sAvSvaOiaMl8FYU4trnEzCwiRr8XMWgAHzlrWpTSj+QaCSvOf1h82OEP1s4hiAXhnbXSyFWCf4ldZzZRVA==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/NaturalIntelligence"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "strnum": "^2.1.2"
+            },
+            "bin": {
+                "fxparser": "src/cli/cli.js"
+            }
         },
         "node_modules/fastq": {
             "version": "1.19.1",
@@ -9430,19 +9294,6 @@
             "dev": true,
             "license": "ISC"
         },
-        "node_modules/html-encoding-sniffer": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
-            "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "whatwg-encoding": "^3.1.1"
-            },
-            "engines": {
-                "node": ">=18"
-            }
-        },
         "node_modules/html-escaper": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -9458,34 +9309,6 @@
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/wooorm"
-            }
-        },
-        "node_modules/http-proxy-agent": {
-            "version": "7.0.2",
-            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
-            "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "agent-base": "^7.1.0",
-                "debug": "^4.3.4"
-            },
-            "engines": {
-                "node": ">= 14"
-            }
-        },
-        "node_modules/https-proxy-agent": {
-            "version": "7.0.6",
-            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
-            "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "agent-base": "^7.1.2",
-                "debug": "4"
-            },
-            "engines": {
-                "node": ">= 14"
             }
         },
         "node_modules/human-signals": {
@@ -10289,15 +10112,15 @@
             }
         },
         "node_modules/jake": {
-            "version": "10.9.2",
-            "resolved": "https://registry.npmjs.org/jake/-/jake-10.9.2.tgz",
-            "integrity": "sha512-2P4SQ0HrLQ+fw6llpLnOaGAvN2Zu6778SJMrCUwns4fOoG9ayrTiZk3VV8sCPkVZF8ab0zksVpS8FDY5pRCNBA==",
+            "version": "10.9.4",
+            "resolved": "https://registry.npmjs.org/jake/-/jake-10.9.4.tgz",
+            "integrity": "sha512-wpHYzhxiVQL+IV05BLE2Xn34zW1S223hvjtqk0+gsPrwd/8JNLXJgZZM/iPFsYc1xyphF+6M6EvdE5E9MBGkDA==",
             "dev": true,
+            "license": "Apache-2.0",
             "dependencies": {
-                "async": "^3.2.3",
-                "chalk": "^4.0.2",
+                "async": "^3.2.6",
                 "filelist": "^1.0.4",
-                "minimatch": "^3.1.2"
+                "picocolors": "^1.1.1"
             },
             "bin": {
                 "jake": "bin/cli.js"
@@ -11168,47 +10991,6 @@
                 "js-yaml": "bin/js-yaml.js"
             }
         },
-        "node_modules/jsdom": {
-            "version": "25.0.1",
-            "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-25.0.1.tgz",
-            "integrity": "sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "cssstyle": "^4.1.0",
-                "data-urls": "^5.0.0",
-                "decimal.js": "^10.4.3",
-                "form-data": "^4.0.0",
-                "html-encoding-sniffer": "^4.0.0",
-                "http-proxy-agent": "^7.0.2",
-                "https-proxy-agent": "^7.0.5",
-                "is-potential-custom-element-name": "^1.0.1",
-                "nwsapi": "^2.2.12",
-                "parse5": "^7.1.2",
-                "rrweb-cssom": "^0.7.1",
-                "saxes": "^6.0.0",
-                "symbol-tree": "^3.2.4",
-                "tough-cookie": "^5.0.0",
-                "w3c-xmlserializer": "^5.0.0",
-                "webidl-conversions": "^7.0.0",
-                "whatwg-encoding": "^3.1.1",
-                "whatwg-mimetype": "^4.0.0",
-                "whatwg-url": "^14.0.0",
-                "ws": "^8.18.0",
-                "xml-name-validator": "^5.0.0"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "peerDependencies": {
-                "canvas": "^2.11.2"
-            },
-            "peerDependenciesMeta": {
-                "canvas": {
-                    "optional": true
-                }
-            }
-        },
         "node_modules/jsesc": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
@@ -11546,13 +11328,17 @@
             }
         },
         "node_modules/loader-runner": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.0.tgz",
-            "integrity": "sha512-3R/1M+yS3j5ou80Me59j7F9IMs4PXs3VqRrm0TU3AbKPxlmpoY1TNscJV/oGJXo8qCatFGTfDbY6W6ipGOYXfg==",
+            "version": "4.3.1",
+            "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.1.tgz",
+            "integrity": "sha512-IWqP2SCPhyVFTBtRcgMHdzlf9ul25NwaFx4wCEH/KjAXuuHY4yNjvPXsBokp8jCB936PyWRaPKUNh8NvylLp2Q==",
             "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=6.11.5"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/webpack"
             }
         },
         "node_modules/loader-utils": {
@@ -11578,9 +11364,9 @@
             }
         },
         "node_modules/lodash": {
-            "version": "4.17.21",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-            "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+            "version": "4.17.23",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
+            "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
             "dev": true,
             "license": "MIT"
         },
@@ -11759,9 +11545,9 @@
             }
         },
         "node_modules/markdown-it": {
-            "version": "14.1.0",
-            "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.0.tgz",
-            "integrity": "sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==",
+            "version": "14.1.1",
+            "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.1.tgz",
+            "integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -13189,10 +12975,11 @@
             "dev": true
         },
         "node_modules/node-releases": {
-            "version": "2.0.19",
-            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
-            "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
-            "dev": true
+            "version": "2.0.27",
+            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
+            "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/normalize-package-data": {
             "version": "3.0.3",
@@ -15444,13 +15231,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/rrweb-cssom": {
-            "version": "0.7.1",
-            "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.7.1.tgz",
-            "integrity": "sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/run-parallel": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -15592,9 +15372,9 @@
             }
         },
         "node_modules/schema-utils": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.0.tgz",
-            "integrity": "sha512-Gf9qqc58SpCA/xdziiHz35F4GNIWYWZrEshUc/G/r5BnLph6xpKuLeoJoQuj5WfBIx/eQLf+hmVPYHaxJu7V2g==",
+            "version": "4.3.3",
+            "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.3.tgz",
+            "integrity": "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -16256,6 +16036,19 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/strnum": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.1.2.tgz",
+            "integrity": "sha512-l63NF9y/cLROq/yqKXSLtcMeeyOfnSQlfMSlzFt/K73oIaD8DGaQWd7Z34X9GPiKqP5rbSh84Hl4bOlLcjiSrQ==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/NaturalIntelligence"
+                }
+            ],
+            "license": "MIT"
+        },
         "node_modules/style-inject": {
             "version": "0.3.0",
             "resolved": "https://registry.npmjs.org/style-inject/-/style-inject-0.3.0.tgz",
@@ -16368,13 +16161,17 @@
             }
         },
         "node_modules/tapable": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
-            "integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.0.tgz",
+            "integrity": "sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==",
             "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=6"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/webpack"
             }
         },
         "node_modules/terra-draw": {
@@ -16413,9 +16210,9 @@
             }
         },
         "node_modules/terser-webpack-plugin": {
-            "version": "5.3.14",
-            "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.14.tgz",
-            "integrity": "sha512-vkZjpUjb6OMS7dhV+tILUW6BhpDR7P2L/aQSAv+Uwk+m8KATX9EccViHTJR2qDtACKPIYndLGCyl3FMo+r2LMw==",
+            "version": "5.3.16",
+            "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.16.tgz",
+            "integrity": "sha512-h9oBFCWrq78NyWWVcSwZarJkZ01c2AyGrzs1crmHZO3QUg9D61Wu4NPjBy69n7JqylFF5y+CsUZYmYEIZ3mR+Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -16599,26 +16396,6 @@
                 "globrex": "^0.1.2"
             }
         },
-        "node_modules/tldts": {
-            "version": "6.1.85",
-            "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.85.tgz",
-            "integrity": "sha512-gBdZ1RjCSevRPFix/hpaUWeak2/RNUZB4/8frF1r5uYMHjFptkiT0JXIebWvgI/0ZHXvxaUDDJshiA0j6GdL3w==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "tldts-core": "^6.1.85"
-            },
-            "bin": {
-                "tldts": "bin/cli.js"
-            }
-        },
-        "node_modules/tldts-core": {
-            "version": "6.1.85",
-            "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.85.tgz",
-            "integrity": "sha512-DTjUVvxckL1fIoPSb3KE7ISNtkWSawZdpfxGxwiIrZoO6EbHVDXXUIlIuWympPaeS+BLGyggozX/HTMsRAdsoA==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/tmpl": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
@@ -16635,32 +16412,6 @@
             },
             "engines": {
                 "node": ">=8.0"
-            }
-        },
-        "node_modules/tough-cookie": {
-            "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
-            "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
-            "dev": true,
-            "license": "BSD-3-Clause",
-            "dependencies": {
-                "tldts": "^6.1.32"
-            },
-            "engines": {
-                "node": ">=16"
-            }
-        },
-        "node_modules/tr46": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.0.tgz",
-            "integrity": "sha512-IUWnUK7ADYR5Sl1fZlO1INDUhVhatWl7BtJWsIhwJ0UAK7ilzzIa8uIqOO/aYVWHZPJkKbEL+362wrzoeRF7bw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "punycode": "^2.3.1"
-            },
-            "engines": {
-                "node": ">=18"
             }
         },
         "node_modules/trim-lines": {
@@ -16698,20 +16449,20 @@
             }
         },
         "node_modules/ts-jest": {
-            "version": "29.3.1",
-            "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.3.1.tgz",
-            "integrity": "sha512-FT2PIRtZABwl6+ZCry8IY7JZ3xMuppsEV9qFVHOVe8jDzggwUZ9TsM4chyJxL9yi6LvkqcZYU3LmapEE454zBQ==",
+            "version": "29.4.6",
+            "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.6.tgz",
+            "integrity": "sha512-fSpWtOO/1AjSNQguk43hb/JCo16oJDnMJf3CdEGNkqsEX3t0KX96xvyX1D7PfLCpVoKu4MfVrqUkFyblYoY4lA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "bs-logger": "^0.2.6",
-                "ejs": "^3.1.10",
                 "fast-json-stable-stringify": "^2.1.0",
-                "jest-util": "^29.0.0",
+                "handlebars": "^4.7.8",
                 "json5": "^2.2.3",
                 "lodash.memoize": "^4.1.2",
                 "make-error": "^1.3.6",
-                "semver": "^7.7.1",
-                "type-fest": "^4.38.0",
+                "semver": "^7.7.3",
+                "type-fest": "^4.41.0",
                 "yargs-parser": "^21.1.1"
             },
             "bin": {
@@ -16722,10 +16473,11 @@
             },
             "peerDependencies": {
                 "@babel/core": ">=7.0.0-beta.0 <8",
-                "@jest/transform": "^29.0.0",
-                "@jest/types": "^29.0.0",
-                "babel-jest": "^29.0.0",
-                "jest": "^29.0.0",
+                "@jest/transform": "^29.0.0 || ^30.0.0",
+                "@jest/types": "^29.0.0 || ^30.0.0",
+                "babel-jest": "^29.0.0 || ^30.0.0",
+                "jest": "^29.0.0 || ^30.0.0",
+                "jest-util": "^29.0.0 || ^30.0.0",
                 "typescript": ">=4.3 <6"
             },
             "peerDependenciesMeta": {
@@ -16743,14 +16495,18 @@
                 },
                 "esbuild": {
                     "optional": true
+                },
+                "jest-util": {
+                    "optional": true
                 }
             }
         },
         "node_modules/ts-jest/node_modules/semver": {
-            "version": "7.7.1",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
-            "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+            "version": "7.7.4",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+            "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
             "dev": true,
+            "license": "ISC",
             "bin": {
                 "semver": "bin/semver.js"
             },
@@ -16759,10 +16515,11 @@
             }
         },
         "node_modules/ts-jest/node_modules/type-fest": {
-            "version": "4.38.0",
-            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.38.0.tgz",
-            "integrity": "sha512-2dBz5D5ycHIoliLYLi0Q2V7KRaDlH0uWIvmk7TYlAg5slqwiPv1ezJdZm1QEM0xgk29oYWMCbIG7E6gHpvChlg==",
+            "version": "4.41.0",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+            "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
             "dev": true,
+            "license": "(MIT OR CC0-1.0)",
             "engines": {
                 "node": ">=16"
             },
@@ -17248,9 +17005,9 @@
             }
         },
         "node_modules/update-browserslist-db": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.3.tgz",
-            "integrity": "sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==",
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+            "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
             "dev": true,
             "funding": [
                 {
@@ -17266,6 +17023,7 @@
                     "url": "https://github.com/sponsors/ai"
                 }
             ],
+            "license": "MIT",
             "dependencies": {
                 "escalade": "^3.2.0",
                 "picocolors": "^1.1.1"
@@ -17388,19 +17146,6 @@
                 "url": "https://opencollective.com/unified"
             }
         },
-        "node_modules/w3c-xmlserializer": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
-            "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "xml-name-validator": "^5.0.0"
-            },
-            "engines": {
-                "node": ">=18"
-            }
-        },
         "node_modules/walker": {
             "version": "1.0.8",
             "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.8.tgz",
@@ -17411,9 +17156,9 @@
             }
         },
         "node_modules/watchpack": {
-            "version": "2.4.2",
-            "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.2.tgz",
-            "integrity": "sha512-TnbFSbcOCcDgjZ4piURLCbJ3nJhznVh9kw6F6iokjiFPl8ONxe9A6nMDVXDiNbrSfLILs6vB07F7wLBrwPYzJw==",
+            "version": "2.5.1",
+            "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.5.1.tgz",
+            "integrity": "sha512-Zn5uXdcFNIA1+1Ei5McRd+iRzfhENPCe7LeABkJtNulSxjma+l7ltNx55BWZkRlwRnpOgHqxnjyaDgJnNXnqzg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -17446,35 +17191,37 @@
             }
         },
         "node_modules/webpack": {
-            "version": "5.98.0",
-            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.98.0.tgz",
-            "integrity": "sha512-UFynvx+gM44Gv9qFgj0acCQK2VE1CtdfwFdimkapco3hlPCJ/zeq73n2yVKimVbtm+TnApIugGhLJnkU6gjYXA==",
+            "version": "5.105.2",
+            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.105.2.tgz",
+            "integrity": "sha512-dRXm0a2qcHPUBEzVk8uph0xWSjV/xZxenQQbLwnwP7caQCYpqG1qddwlyEkIDkYn0K8tvmcrZ+bOrzoQ3HxCDw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/eslint-scope": "^3.7.7",
-                "@types/estree": "^1.0.6",
+                "@types/estree": "^1.0.8",
+                "@types/json-schema": "^7.0.15",
                 "@webassemblyjs/ast": "^1.14.1",
                 "@webassemblyjs/wasm-edit": "^1.14.1",
                 "@webassemblyjs/wasm-parser": "^1.14.1",
-                "acorn": "^8.14.0",
-                "browserslist": "^4.24.0",
+                "acorn": "^8.15.0",
+                "acorn-import-phases": "^1.0.3",
+                "browserslist": "^4.28.1",
                 "chrome-trace-event": "^1.0.2",
-                "enhanced-resolve": "^5.17.1",
-                "es-module-lexer": "^1.2.1",
+                "enhanced-resolve": "^5.19.0",
+                "es-module-lexer": "^2.0.0",
                 "eslint-scope": "5.1.1",
                 "events": "^3.2.0",
                 "glob-to-regexp": "^0.4.1",
                 "graceful-fs": "^4.2.11",
                 "json-parse-even-better-errors": "^2.3.1",
-                "loader-runner": "^4.2.0",
+                "loader-runner": "^4.3.1",
                 "mime-types": "^2.1.27",
                 "neo-async": "^2.6.2",
-                "schema-utils": "^4.3.0",
-                "tapable": "^2.1.1",
-                "terser-webpack-plugin": "^5.3.11",
-                "watchpack": "^2.4.1",
-                "webpack-sources": "^3.2.3"
+                "schema-utils": "^4.3.3",
+                "tapable": "^2.3.0",
+                "terser-webpack-plugin": "^5.3.16",
+                "watchpack": "^2.5.1",
+                "webpack-sources": "^3.3.3"
             },
             "bin": {
                 "webpack": "bin/webpack.js"
@@ -17493,9 +17240,9 @@
             }
         },
         "node_modules/webpack-sources": {
-            "version": "3.2.3",
-            "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.3.tgz",
-            "integrity": "sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==",
+            "version": "3.3.4",
+            "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.3.4.tgz",
+            "integrity": "sha512-7tP1PdV4vF+lYPnkMR0jMY5/la2ub5Fc/8VQrrU+lXkiM6C4TjVfGw7iKfyhnTQOsD+6Q/iKw0eFciziRgD58Q==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -17524,43 +17271,6 @@
             "license": "BSD-2-Clause",
             "engines": {
                 "node": ">=4.0"
-            }
-        },
-        "node_modules/whatwg-encoding": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
-            "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "iconv-lite": "0.6.3"
-            },
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/whatwg-mimetype": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
-            "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/whatwg-url": {
-            "version": "14.2.0",
-            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
-            "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "tr46": "^5.1.0",
-                "webidl-conversions": "^7.0.0"
-            },
-            "engines": {
-                "node": ">=18"
             }
         },
         "node_modules/which": {
@@ -17810,16 +17520,6 @@
                 "utf-8-validate": {
                     "optional": true
                 }
-            }
-        },
-        "node_modules/xml-name-validator": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
-            "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "engines": {
-                "node": ">=18"
             }
         },
         "node_modules/xmlchars": {

--- a/src/routing.spec.ts
+++ b/src/routing.spec.ts
@@ -181,6 +181,78 @@ describe("Routing", () => {
     });
 
     describe("setNetwork", () => {
+        it("should reindex from scratch on repeated setNetwork calls", () => {
+            const routing = new Routing({ network, routeFinder: mockRouteFinder });
+
+            const secondNetwork: FeatureCollection<LineString> = {
+                type: "FeatureCollection",
+                features: [
+                    {
+                        type: "Feature",
+                        geometry: {
+                            type: "LineString",
+                            coordinates: [
+                                [10, 10],
+                                [11, 11],
+                            ],
+                        },
+                        properties: {},
+                    },
+                ],
+            };
+
+            const thirdNetwork: FeatureCollection<LineString> = {
+                type: "FeatureCollection",
+                features: [
+                    {
+                        type: "Feature",
+                        geometry: {
+                            type: "LineString",
+                            coordinates: [
+                                [20, 20],
+                                [21, 21],
+                            ],
+                        },
+                        properties: {},
+                    },
+                ],
+            };
+
+            routing.setNetwork(secondNetwork);
+            routing.setNetwork(thirdNetwork);
+
+            expect(routing.getNodeCount()).toBe(2);
+            expect(routing.getClosestNetworkCoordinate([20, 20])).toEqual([20, 20]);
+            expect(routing.getClosestNetworkCoordinate([0, 0])).toEqual([20, 20]);
+        });
+
+        it("should not return stale closest coordinates from the previous network", () => {
+            const routing = new Routing({ network, routeFinder: mockRouteFinder });
+
+            const replacementNetwork: FeatureCollection<LineString> = {
+                type: "FeatureCollection",
+                features: [
+                    {
+                        type: "Feature",
+                        geometry: {
+                            type: "LineString",
+                            coordinates: [
+                                [10, 10],
+                                [11, 11],
+                            ],
+                        },
+                        properties: {},
+                    },
+                ],
+            };
+
+            routing.setNetwork(replacementNetwork);
+
+            // The previous network point [0,0] should no longer be indexed.
+            expect(routing.getClosestNetworkCoordinate([0, 0])).toEqual([10, 10]);
+            expect(routing.getClosestNetworkCoordinate([1, 1])).toEqual([10, 10]);
+        });
+
         it("should clear the route cache when the network is replaced", () => {
             const routing = new Routing({ network, routeFinder: mockRouteFinder, useCache: true });
 

--- a/src/routing.ts
+++ b/src/routing.ts
@@ -57,6 +57,8 @@ export class Routing implements RoutingInterface {
 
   // Initialise the routing instance setting internal data structures
   private initialise() {
+    this.points = [];
+
     this.network.features.forEach((feature) => {
       feature.geometry.coordinates.forEach((coordinate) => {
         this.points.push(coordinate);


### PR DESCRIPTION
## Description of Changes

The points array was not being cleaned up correctly that means when networks were updated old points could still be snapped to even though they were potentially not in the network.

## Link to Issue

No issue

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [ ] There is a associated GitHub issue 
- [x] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 