### PR TITLE
chore: use correct PAT name

### DIFF
--- a/.github/workflows/release-dry-run.yml
+++ b/.github/workflows/release-dry-run.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          token: ${{ secrets.TERRA_DRAW_PAT }}
+          token: ${{ secrets.TERRA_DRAW_ROUTE_SNAP_MODE_PAT }}
 
       - uses: actions/setup-node@v6
         with:
@@ -35,6 +35,6 @@ jobs:
           git config --global user.email "terradraw@githubactions.com"
           git config --global user.name "James Milner"
 
-      - name: Release
+      - name: Release (Dry Run)
         run: npm run release:dryrun
  

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          token: ${{ secrets.TERRA_DRAW_PAT }}
+          token: ${{ secrets.TERRA_DRAW_ROUTE_SNAP_MODE_PAT }}
 
       - uses: actions/setup-node@v6
         with:


### PR DESCRIPTION
## Description of Changes

We use a new PAT just for terra-draw-route-snap-mode

## Link to Issue

No issue

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [ ] There is a associated GitHub issue 
- [ ] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 