### PR TITLE
chore: rename action for dry run release to be clearer

### DIFF
--- a/.github/workflows/release-dry-run.yml
+++ b/.github/workflows/release-dry-run.yml
@@ -7,7 +7,7 @@ permissions:
 on: workflow_dispatch
 
 jobs:
-  release:
+  release-dry-run:
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
## Description of Changes

Renames the dry release action to more clearly show it is a dry run

## Link to Issue

No issue

## PR Checklist

- [x] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [ ] There is a associated GitHub issue 
- [ ] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 