### PR TITLE
chore: upgrade peer dependency for terra-draw

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
                 "typescript": "5.6.3"
             },
             "peerDependencies": {
-                "terra-draw": "^1.4.3"
+                "terra-draw": "^1.22.0"
             }
         },
         "node_modules/@ampproject/remapping": {
@@ -16175,9 +16175,10 @@
             }
         },
         "node_modules/terra-draw": {
-            "version": "1.4.3",
-            "resolved": "https://registry.npmjs.org/terra-draw/-/terra-draw-1.4.3.tgz",
-            "integrity": "sha512-gmvgsdEu5GubY+S3pmuwUVXXVxcgTxOTQX8E8b7LDtGvsfCqVuLXxCA0W79O9OpN7X00xxnqQKoQ/UUrbhiZcQ==",
+            "version": "1.25.0",
+            "resolved": "https://registry.npmjs.org/terra-draw/-/terra-draw-1.25.0.tgz",
+            "integrity": "sha512-SQFdY6ObBqln01NFcYjrsVLPoAxHgl3fJszqU0pkDkxNIbV7FZUM102BcC2v9xXQ5Tr8hhnBELf1qG4GaXcALQ==",
+            "license": "MIT",
             "peer": true
         },
         "node_modules/terra-route": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "author": "James Milner",
     "license": "MIT",
     "peerDependencies": {
-        "terra-draw": "^1.4.3"
+        "terra-draw": "^1.22.0"
     },
     "devDependencies": {
         "@commitlint/cli": "17.1.2",

--- a/src/terra-draw-route-snap-mode.ts
+++ b/src/terra-draw-route-snap-mode.ts
@@ -10,6 +10,7 @@ import { Feature, LineString, Position } from "geojson";
 import { Validation } from "terra-draw/dist/common";
 import { RoutingInterface } from "./routing";
 import { FeatureId } from "terra-draw/dist/extend";
+import { isContext } from "vm";
 
 type TerraDrawRouteSnapModeKeyEvents = {
   cancel: KeyboardEvent["key"] | null;
@@ -151,7 +152,8 @@ export class TerraDrawRouteSnapMode extends TerraDrawBaseDrawMode<RouteSnapStyli
       containerX: x,
       containerY: y,
       button: 'left' as const,
-      heldKeys: []
+      heldKeys: [],
+      isContextMenu: false,
     }
     const distToPrevious = this.measure(previousEvent, coordinateTwo);
 


### PR DESCRIPTION
## Description of Changes

Changes peer-dependency for terra-draw to 1.22.0

## Link to Issue

No issue

## PR Checklist

- [ ] The PR title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) standard
- [ ] There is a associated GitHub issue 
- [ ] If I have added significant code changes, there are relevant tests
- [ ] If there are behaviour changes these are documented 